### PR TITLE
Pass StaticHostingStack properties to parent constructor

### DIFF
--- a/lib/static-hosting-stack.ts
+++ b/lib/static-hosting-stack.ts
@@ -20,7 +20,7 @@ export interface ResourceProps extends StackProps {
 
 export class StaticHostingStack extends Stack {
     constructor(scope: Construct, id: string, props: ResourceProps) {
-        super(scope, id);
+        super(scope, id, props);
 
         const siteName = `${props.subDomainName}.${props.domainName}`;
         const siteNameArray: Array<string> = [siteName];


### PR DESCRIPTION
Currently the StaticHostingStack does not pass `props` when calling super.
This means that the default props such as `env` are not set.